### PR TITLE
Command change #call to #perform, force validations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,11 @@
 
 ### Added
 - Commands usage examples
+- Commands: `argument` as an alias for `param`
 
 ### Changed
 - Commands migrate from `#call` to `#perform` method
+- Commands: force validations
 
 ## v0.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,16 @@
 # AuxiliaryRails Changelog
 
+## [Unreleased]
+
+### Added
+- Commands usage examples
+
+### Changed
+- Commands migrate from `#call` to `#perform` method
+
 ## v0.2.0
 
 * Commands migration to `dry-initializer`
-* Commands usage examples
 
 ## v0.1.7
 
@@ -26,7 +33,7 @@
 
 ## v0.1.3
 
-* Upgrate `rubocop` gem and its configs
+* Upgrade `rubocop` gem and its configs
 * `rubocop-rspec` and `rubocop-performance` gem iteration
 * Added basic Rails application template
 * CLI with `create_rails_app` command

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ class RegisterUserCommand < ApplicationCommand
   # where command's flow is defined
   def perform
     # Use `return failure!` to exit from the command with failure
-    return failure! if invalid?
+    return failure! if registration_disabled?
 
     # Method `#transaction` is a shortcut for `ActiveRecord::Base.transaction`
     transaction do

--- a/README.md
+++ b/README.md
@@ -87,16 +87,16 @@ class RegisterUserCommand < ApplicationCommand
   # https://api.rubyonrails.org/classes/ActiveModel/Validations.html
   validates :password, length: { in: 8..32 }
 
-  # Define the only public method `#call`
+  # Define the only public method `#perform`
   # where command's flow is defined
-  def call
+  def perform
     # Use `return failure!` to exit from the command with failure
     return failure! if invalid?
 
     # Method `#transaction` is a shortcut for `ActiveRecord::Base.transaction`
     transaction do
-      # Keep the `#call` method short and clean, put all the steps and actions
-      # into meaningful and self-explanatory methods
+      # Keep the `#perform` method short and clean, put all the steps, actions
+      # and business logic into meaningful and self-explanatory methods
       create_user
 
       # Use `error!` method to interrupt the flow raising an error
@@ -106,7 +106,7 @@ class RegisterUserCommand < ApplicationCommand
       # ...
     end
 
-    # Always end the `#call` method with `success!`
+    # Always end the `#perform` method with `success!`
     # this will set the proper status and allow to chain command methods.
     success!
   end

--- a/lib/auxiliary_rails/abstract_command.rb
+++ b/lib/auxiliary_rails/abstract_command.rb
@@ -6,8 +6,17 @@ module AuxiliaryRails
     extend Dry::Initializer
     include ActiveModel::Validations
 
-    def self.call(*args)
-      new(*args).call
+    class << self
+      alias argument param
+
+      def call(*args)
+        new(*args).call
+      end
+
+      # Method for ActiveModel::Translation
+      def i18n_scope
+        :commands
+      end
     end
 
     def call
@@ -48,18 +57,17 @@ module AuxiliaryRails
       if attr_name == :command
         self
       else
-        self.class.dry_initializer.attributes(self)[attr_name]
+        arguments[attr_name]
       end
-    end
-
-    # Method for ActiveModel::Translation
-    def self.i18n_scope
-      :commands
     end
 
     protected
 
     attr_accessor :status
+
+    def arguments
+      self.class.dry_initializer.attributes(self)
+    end
 
     def ensure_empty_errors!
       return if errors.empty?

--- a/lib/auxiliary_rails/abstract_command.rb
+++ b/lib/auxiliary_rails/abstract_command.rb
@@ -19,8 +19,12 @@ module AuxiliaryRails
       end
     end
 
-    def call
+    def call(options = {})
       ensure_empty_status!
+
+      if options[:validate] != false && invalid?
+        return failure!('Validation failed')
+      end
 
       perform
 

--- a/lib/auxiliary_rails/abstract_command.rb
+++ b/lib/auxiliary_rails/abstract_command.rb
@@ -11,6 +11,15 @@ module AuxiliaryRails
     end
 
     def call
+      ensure_empty_status!
+
+      perform
+
+      ensure_execution!
+      self
+    end
+
+    def perform
       raise NotImplementedError
     end
 

--- a/lib/generators/auxiliary_rails/templates/commands/command_template.rb
+++ b/lib/generators/auxiliary_rails/templates/commands/command_template.rb
@@ -1,6 +1,6 @@
 class <%= command_class_name %> < ApplicationCommand
-  def call
-    # TODO: implement <%= command_class_name %>.call method
+  def perform
+    # TODO: implement <%= command_class_name %>.perform method
     success!
   end
 end

--- a/spec/sample_commands_spec.rb
+++ b/spec/sample_commands_spec.rb
@@ -74,6 +74,12 @@ RSpec.describe SampleCommands do
         expect(cmd.call).to be_failure
         expect(cmd.errors[:age]).to include 'must be greater than 18'
       end
+
+      context 'when option to skip validation set' do
+        it do
+          expect(cmd.call(validate: false)).to be_success
+        end
+      end
     end
   end
 end

--- a/spec/support/sample_classes/sample_commands.rb
+++ b/spec/support/sample_classes/sample_commands.rb
@@ -39,8 +39,6 @@ module SampleCommands
       }
 
     def perform
-      return failure! unless valid?
-
       success!
     end
   end

--- a/spec/support/sample_classes/sample_commands.rb
+++ b/spec/support/sample_classes/sample_commands.rb
@@ -3,27 +3,27 @@ end
 
 module SampleCommands
   class SuccessCommand < AuxiliaryRails::AbstractCommand
-    def call
+    def perform
       success!
     end
   end
 
   class DoubleStatusSetCommand < AuxiliaryRails::AbstractCommand
-    def call
+    def perform
       failure!
       success!
     end
   end
 
   class SuccessWithErrorsCommand < AuxiliaryRails::AbstractCommand
-    def call
+    def perform
       errors.add(:command, :error)
       success!
     end
   end
 
   class FailureWithErrorsCommand < AuxiliaryRails::AbstractCommand
-    def call
+    def perform
       errors.add(:command, :test_failure_message)
       failure!
     end
@@ -38,7 +38,7 @@ module SampleCommands
         greater_than: 18
       }
 
-    def call
+    def perform
       return failure! unless valid?
 
       success!

--- a/spec/support/sample_classes/sample_commands.rb
+++ b/spec/support/sample_classes/sample_commands.rb
@@ -30,7 +30,7 @@ module SampleCommands
   end
 
   class ValidationErrorsCommand < AuxiliaryRails::AbstractCommand
-    param :age
+    argument :age
 
     validates :age,
       numericality: {


### PR DESCRIPTION
Reason:
* ability to wrap `#perform` method in call with extra control
* force validation to make mimic habitual ActiveRecord#save behavior.