### PR TITLE
Commands: rename `status` to `command_status`

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,6 @@ class RegisterUserCommand < ApplicationCommand
   # Define command arguments
   # using `param` or `option` methods provided by dry-initializer
   # https://dry-rb.org/gems/dry-initializer/3.0/
-  # Don't use reserved names like :status - it'll produce error
   param :email
   param :password
 
@@ -86,7 +85,7 @@ class RegisterUserCommand < ApplicationCommand
 
   # Regular Active Model Validations can be used to validate params
   # https://api.rubyonrails.org/classes/ActiveModel/Validations.html
-  # Use #valid?, #invalid?, #validate methods to engage validations
+  # Use #valid?, #invalid?, #validate! methods to engage validations
   validates :password, length: { in: 8..32 }
 
   # Define the only public method `#call`

--- a/lib/auxiliary_rails/abstract_command.rb
+++ b/lib/auxiliary_rails/abstract_command.rb
@@ -21,7 +21,7 @@ module AuxiliaryRails
     def status?(value)
       ensure_execution!
 
-      status == value&.to_sym
+      command_status == value&.to_sym
     end
 
     def success?
@@ -50,7 +50,7 @@ module AuxiliaryRails
 
     protected
 
-    attr_accessor :status
+    attr_accessor :command_status
 
     def ensure_empty_errors!
       return if errors.empty?
@@ -59,13 +59,13 @@ module AuxiliaryRails
     end
 
     def ensure_empty_status!
-      return if status.nil?
+      return if command_status.nil?
 
       error!("`#{self.class}` was already executed.")
     end
 
     def ensure_execution!
-      return if status.present?
+      return if command_status.present?
 
       error!("`#{self.class}` was not executed yet.")
     end
@@ -80,7 +80,7 @@ module AuxiliaryRails
 
       errors.add(:command, :failed, message: message) unless message.nil?
 
-      self.status = :failure
+      self.command_status = :failure
       self
     end
 
@@ -88,7 +88,7 @@ module AuxiliaryRails
       ensure_empty_errors!
       ensure_empty_status!
 
-      self.status = :success
+      self.command_status = :success
       self
     end
   end


### PR DESCRIPTION
This change allows to use common name `status` for command arguments.