### PR TITLE
Update cli.rb - fix whitespace on new command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,22 @@
 # AuxiliaryRails Changelog
 
-## [Unreleased]
+## v0.3.0
 
 ### Added
+- Form Objects
+- Query Objects
+- Performable concern
+- YARD docs and link to API documentation
 - Commands usage examples
 - Commands: `arguments` helper to get hash of all `param`s
 
 ### Changed
+- Namespace `Application` instead of `Abstract` prefixes for classes
 - Commands migrate from `#call` to `#perform` method
 - Commands: force validations
 
 ### Removed
-- RuboCop generator, replaces with `rubocop-ergoserv` gem
+- RuboCop generator replaced with `rubocop-ergoserv` gem
 
 ## v0.2.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    auxiliary_rails (0.2.0)
+    auxiliary_rails (0.3.0)
       dry-core
       dry-initializer
       dry-initializer-rails

--- a/lib/auxiliary_rails/cli.rb
+++ b/lib/auxiliary_rails/cli.rb
@@ -30,7 +30,7 @@ module AuxiliaryRails
     def new(app_path)
       run "rails new #{app_path} " \
         "--database=#{options[:database]} " \
-        "--template=#{rails_template_path(options[:template])}" \
+        "--template=#{rails_template_path(options[:template])} " \
         '--skip-action-cable ' \
         '--skip-coffee ' \
         '--skip-test ' \

--- a/lib/auxiliary_rails/version.rb
+++ b/lib/auxiliary_rails/version.rb
@@ -1,3 +1,3 @@
 module AuxiliaryRails
-  VERSION = '0.2.0'.freeze
+  VERSION = '0.3.0'.freeze
 end


### PR DESCRIPTION
Fix issue when run `auxiliary_rails new APP_PATH --develop`.

```
 apply  https://raw.githubusercontent.com/ergoserv/auxiliary_rails/develop/templates/rails/elementary.rb--skip-action-cable
/Users/BKucherevych/.rvm/gems/ruby-2.7.0/gems/thor-1.0.1/lib/thor/actions.rb:222: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
Traceback (most recent call last):
```