### PR TITLE
Update cli.rb - fix whitespace on new command

### DIFF
--- a/lib/auxiliary_rails/cli.rb
+++ b/lib/auxiliary_rails/cli.rb
@@ -30,7 +30,7 @@ module AuxiliaryRails
     def new(app_path)
       run "rails new #{app_path} " \
         "--database=#{options[:database]} " \
-        "--template=#{rails_template_path(options[:template])}" \
+        "--template=#{rails_template_path(options[:template])} " \
         '--skip-action-cable ' \
         '--skip-coffee ' \
         '--skip-test ' \


### PR DESCRIPTION
Fix issue when run auxiliary_rails new APP_PATH --develop. 
```
apply  https://raw.githubusercontent.com/ergoserv/auxiliary_rails/develop/templates/rails/elementary.rb--skip-action-cable
/Users/BKucherevych/.rvm/gems/ruby-2.7.0/gems/thor-1.0.1/lib/thor/actions.rb:222: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
Traceback (most recent call last):
```