### PR TITLE
Fix `failure!` argument error (ruby 3)

### DIFF
--- a/lib/auxiliary_rails/concerns/performable.rb
+++ b/lib/auxiliary_rails/concerns/performable.rb
@@ -94,7 +94,7 @@ module AuxiliaryRails
       def failure!(message = nil, options = {})
         ensure_empty_status!
 
-        errors.add(:base, message, options) if message.present?
+        errors.add(:base, message, **options) if message.present?
 
         self.performable_status = :failure
         self

--- a/spec/sample_commands_spec.rb
+++ b/spec/sample_commands_spec.rb
@@ -72,4 +72,16 @@ RSpec.describe SampleCommands do
       end
     end
   end
+
+  describe 'FailureMessageErrorsCommand' do
+    subject(:cmd) { SampleCommands::FailureMessageErrorsCommand.new }
+
+    describe '#call' do
+      it do
+        expect(cmd.call).to be_failure
+        expect(cmd.errors.first.options).to eq foo: :bar
+        expect(cmd.errors.full_messages.join(', ')).to eq 'Custom failure message!'
+      end
+    end
+  end
 end

--- a/spec/support/sample_classes/sample_commands.rb
+++ b/spec/support/sample_classes/sample_commands.rb
@@ -32,4 +32,10 @@ module SampleCommands
       success!
     end
   end
+
+  class FailureMessageErrorsCommand < AuxiliaryRails::Application::Command
+    def perform
+      failure!('Custom failure message!', { foo: :bar })
+    end
+  end
 end


### PR DESCRIPTION
docs:
https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
https://rubyreferences.github.io/rubychanges/3.0.html#keyword-arguments-are-now-fully-separated-from-positional-arguments

similar fixes:
https://github.com/toptal/database_validations/pull/54/files
https://github.com/rails/rails/pull/42638/files#r660632570